### PR TITLE
maintain compatibility after scipy cumtrapz deprecation

### DIFF
--- a/AUG/fetch_data.py
+++ b/AUG/fetch_data.py
@@ -16,7 +16,10 @@ import xarray
 import re,sys
 #np.seterr(all='raise')
 from IPython import embed
-
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
 
 #Note about output errorbars:
 #positive finite - OK
@@ -1423,7 +1426,6 @@ class data_loader:
             TDI = ['\\NB::TOP.NB{0}:PINJ_{0}'.format(beam) for beam in load_beams] +['\\NB::TOP:TIMEBASE']
             PINJ = mds_load(self.MDSconn, TDI, 'NB', self.shot)
             beam_time = PINJ[-1]
-            from scipy.integrate import cumtrapz
             nbi_cum_pow = cumtrapz(np.double(PINJ[:-1]),beam_time,initial=0)
             
   

--- a/AUG/fetch_data.py
+++ b/AUG/fetch_data.py
@@ -16,10 +16,8 @@ import xarray
 import re,sys
 #np.seterr(all='raise')
 from IPython import embed
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
+
 
 #Note about output errorbars:
 #positive finite - OK

--- a/AUG/map_equ.py
+++ b/AUG/map_equ.py
@@ -8,6 +8,11 @@ from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys
 sys.path.append('/afs/ipp/aug/ads-diags/common/python/lib/')
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
+
 
 #import dd_20140407
 
@@ -1002,7 +1007,6 @@ class equ_map:
         
         theta = np.unwrap(theta - theta[:, (0, )], axis=1)
         
-        from scipy.integrate import cumtrapz
 
 # Definition of the theta star by integral
         theta_star = cumtrapz(dtheta_star, theta, axis=1, initial=0)

--- a/AUG/map_equ.py
+++ b/AUG/map_equ.py
@@ -8,10 +8,8 @@ from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys
 sys.path.append('/afs/ipp/aug/ads-diags/common/python/lib/')
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
+
 
 
 #import dd_20140407

--- a/CMOD/map_equ.py
+++ b/CMOD/map_equ.py
@@ -7,10 +7,8 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
+
 from IPython import embed
 
 

--- a/CMOD/map_equ.py
+++ b/CMOD/map_equ.py
@@ -7,7 +7,10 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-from scipy import integrate
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
 from IPython import embed
 
 
@@ -318,7 +321,7 @@ class equ_map:
         #IPython.embed()
 
         #The toroidal flux PHI can be found by recognizing that the safety factor is the ratio of the differential toroidal and poloidal fluxes
-        self.tf = integrate.cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
+        self.tf = cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
         
 
 
@@ -1107,8 +1110,6 @@ class equ_map:
         
         theta = np.unwrap(theta - theta[:, (0, )], axis=1)
         
-        from scipy.integrate import cumtrapz
-
 # Definition of the theta star by integral
         theta_star = cumtrapz(dtheta_star, theta, axis=1, initial=0)
         correction = (n_theta - 1.)/n_theta

--- a/CMOD/map_equ_eqdsk.py
+++ b/CMOD/map_equ_eqdsk.py
@@ -7,10 +7,7 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
 
 
 

--- a/CMOD/map_equ_eqdsk.py
+++ b/CMOD/map_equ_eqdsk.py
@@ -7,7 +7,10 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-from scipy import integrate
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
 
 
 
@@ -250,7 +253,7 @@ class equ_map:
         #self.vol = np.array([self.eqdsk[t]['fluxSurfaces']['geo']['vol'] for t in self.times]).T
 
         #The toroidal flux PHI can be found by recognizing that the safety factor is the ratio of the differential toroidal and poloidal fluxes
-        self.tf = integrate.cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
+        self.tf = cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
 
         from scipy.constants import mu_0
 
@@ -1132,7 +1135,6 @@ class equ_map:
 
         theta = np.unwrap(theta - theta[:, (0, )], axis=1)
 
-        from scipy.integrate import cumtrapz
 
 # Definition of the theta star by integral
         theta_star = cumtrapz(dtheta_star, theta, axis=1, initial=0)

--- a/D3D/fetch_data.py
+++ b/D3D/fetch_data.py
@@ -18,10 +18,8 @@ import re,sys,os
 #np.seterr(all='raise')
 from IPython import embed
 from scipy.stats import trim_mean
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
+
 import matplotlib.pylab as plt
 import warnings
 import sys

--- a/D3D/fetch_data.py
+++ b/D3D/fetch_data.py
@@ -18,7 +18,10 @@ import re,sys,os
 #np.seterr(all='raise')
 from IPython import embed
 from scipy.stats import trim_mean
-from scipy.integrate import cumtrapz
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
 import matplotlib.pylab as plt
 import warnings
 import sys

--- a/D3D/map_equ.py
+++ b/D3D/map_equ.py
@@ -7,10 +7,8 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
+
 from IPython import embed
 
 

--- a/D3D/map_equ.py
+++ b/D3D/map_equ.py
@@ -7,7 +7,10 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-from scipy import integrate
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
 from IPython import embed
 
 
@@ -334,7 +337,7 @@ class equ_map:
         #self.vol  =  V0*self.sf.get(self.gEQDSK+'RHOVN').data()[self.valid].T**2
 
         #The toroidal flux PHI can be found by recognizing that the safety factor is the ratio of the differential toroidal and poloidal fluxes
-        self.tf = integrate.cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0) #normalised toroidal flux is self.gEQDSK+'RHOVN'
+        self.tf = cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0) #normalised toroidal flux is self.gEQDSK+'RHOVN'
     
     def _get_nearest_index(self, tarr):
 
@@ -1128,8 +1131,6 @@ class equ_map:
         
         theta = np.unwrap(theta - theta[:, (0, )], axis=1)
         
-        from scipy.integrate import cumtrapz
-
 # Definition of the theta star by integral
         theta_star = cumtrapz(dtheta_star, theta, axis=1, initial=0)
         correction = (n_theta - 1.)/n_theta

--- a/D3D/map_equ_eqdsk.py
+++ b/D3D/map_equ_eqdsk.py
@@ -7,10 +7,8 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
+
 
 
 

--- a/D3D/map_equ_eqdsk.py
+++ b/D3D/map_equ_eqdsk.py
@@ -7,7 +7,10 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-from scipy import integrate
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
 
 
 
@@ -250,7 +253,7 @@ class equ_map:
         #self.vol = np.array([self.eqdsk[t]['fluxSurfaces']['geo']['vol'] for t in self.times]).T
 
         #The toroidal flux PHI can be found by recognizing that the safety factor is the ratio of the differential toroidal and poloidal fluxes
-        self.tf = integrate.cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
+        self.tf = cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
 
         from scipy.constants import mu_0
 
@@ -1136,8 +1139,6 @@ class equ_map:
         theta = np.arctan2(magz - z0, - magr + r0)
 
         theta = np.unwrap(theta - theta[:, (0, )], axis=1)
-
-        from scipy.integrate import cumtrapz
 
 # Definition of the theta star by integral
         theta_star = cumtrapz(dtheta_star, theta, axis=1, initial=0)

--- a/NSTX/map_equ.py
+++ b/NSTX/map_equ.py
@@ -7,7 +7,10 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-from scipy import integrate
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
 from IPython import embed
  
 
@@ -299,7 +302,7 @@ class equ_map:
         #self.vol  =  V0*self.sf.get(self.gEQDSK+'RHOVN').data()[self.valid].T**2
 
         #The toroidal flux PHI can be found by recognizing that the safety factor is the ratio of the differential toroidal and poloidal fluxes
-        self.tf = integrate.cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
+        self.tf = cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
         #embed()
 
     def _get_nearest_index(self, tarr):
@@ -1093,8 +1096,6 @@ class equ_map:
         
         theta = np.unwrap(theta - theta[:, (0, )], axis=1)
         
-        from scipy.integrate import cumtrapz
-
 # Definition of the theta star by integral
         theta_star = cumtrapz(dtheta_star, theta, axis=1, initial=0)
         correction = (n_theta - 1.)/n_theta

--- a/NSTX/map_equ.py
+++ b/NSTX/map_equ.py
@@ -7,10 +7,8 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
+
 from IPython import embed
  
 

--- a/NSTX/map_equ_eqdsk.py
+++ b/NSTX/map_equ_eqdsk.py
@@ -7,10 +7,8 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-try:
-    from scipy.integrate import cumulative_trapezoid as cumtrapz
-except Exception:
-    from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
+
 
 
 

--- a/NSTX/map_equ_eqdsk.py
+++ b/NSTX/map_equ_eqdsk.py
@@ -7,7 +7,10 @@ import numpy as np
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, interp1d, InterpolatedUnivariateSpline, LinearNDInterpolator
 import sys,os
-from scipy import integrate
+try:
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+except Exception:
+    from scipy.integrate import cumtrapz
 
 
 
@@ -249,7 +252,7 @@ class equ_map:
         #self.vol = np.array([self.eqdsk[t]['fluxSurfaces']['geo']['vol'] for t in self.times]).T
 
         #The toroidal flux PHI can be found by recognizing that the safety factor is the ratio of the differential toroidal and poloidal fluxes
-        self.tf = integrate.cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
+        self.tf = cumtrapz(np.sign(self.ip)*np.sign(self.Bt)*self.q,self.pf,initial=0,axis=0)
 
         from scipy.constants import mu_0
 
@@ -1134,8 +1137,6 @@ class equ_map:
         theta = np.arctan2(magz - z0, - magr + r0)
 
         theta = np.unwrap(theta - theta[:, (0, )], axis=1)
-
-        from scipy.integrate import cumtrapz
 
 # Definition of the theta star by integral
         theta_star = cumtrapz(dtheta_star, theta, axis=1, initial=0)


### PR DESCRIPTION
Maintaining compatibility for cumtrapz, which was deprecated in SciPy 1.12 and removed in SciPy 1.14, in favor of cumulative_trapezoid.